### PR TITLE
add new method to create an execution and return the execution object…

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ with valid values for tenantId, apiKey and accessToken
     * [.init(orgId, apiKey, accessToken, baseUrl)](#CloudManagerAPI+init) ⇒ [<code>Promise.&lt;CloudManagerAPI&gt;</code>](#CloudManagerAPI)
     * [.listPrograms()](#CloudManagerAPI+listPrograms) ⇒ <code>Promise.&lt;Array.&lt;EmbeddedProgram&gt;&gt;</code>
     * [.listPipelines(programId, options)](#CloudManagerAPI+listPipelines) ⇒ <code>Promise.&lt;Array.&lt;Pipeline&gt;&gt;</code>
-    * [.startExecution(programId, pipelineId)](#CloudManagerAPI+startExecution) ⇒ <code>Promise.&lt;string&gt;</code>
+    * [.createExecution(programId, pipelineId)](#CloudManagerAPI+createExecution) ⇒ [<code>Promise.&lt;PipelineExecution&gt;</code>](#PipelineExecution)
+    * ~~[.startExecution(programId, pipelineId)](#CloudManagerAPI+startExecution) ⇒ <code>Promise.&lt;string&gt;</code>~~
     * [.getCurrentExecution(programId, pipelineId)](#CloudManagerAPI+getCurrentExecution) ⇒ [<code>Promise.&lt;PipelineExecution&gt;</code>](#PipelineExecution)
     * [.getExecution(programId, pipelineId, executionId)](#CloudManagerAPI+getExecution) ⇒ [<code>Promise.&lt;PipelineExecution&gt;</code>](#PipelineExecution)
     * [.getQualityGateResults(programId, pipelineId, executionId, action)](#CloudManagerAPI+getQualityGateResults) ⇒ [<code>Promise.&lt;PipelineStepMetrics&gt;</code>](#PipelineStepMetrics)
@@ -219,10 +220,25 @@ Obtain a list of pipelines for the target program.
 | programId | <code>string</code> | the program id |
 | options | [<code>ListPipelineOptions</code>](#ListPipelineOptions) | options |
 
+<a name="CloudManagerAPI+createExecution"></a>
+
+### cloudManagerAPI.createExecution(programId, pipelineId) ⇒ [<code>Promise.&lt;PipelineExecution&gt;</code>](#PipelineExecution)
+Create a new execution for a pipeline, returning the execution.
+
+**Kind**: instance method of [<code>CloudManagerAPI</code>](#CloudManagerAPI)  
+**Returns**: [<code>Promise.&lt;PipelineExecution&gt;</code>](#PipelineExecution) - the new execution  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| programId | <code>string</code> | the program id |
+| pipelineId | <code>string</code> | the pipeline id |
+
 <a name="CloudManagerAPI+startExecution"></a>
 
-### cloudManagerAPI.startExecution(programId, pipelineId) ⇒ <code>Promise.&lt;string&gt;</code>
-Start an execution for a pipeline
+### ~~cloudManagerAPI.startExecution(programId, pipelineId) ⇒ <code>Promise.&lt;string&gt;</code>~~
+***Deprecated***
+
+Start an execution for a pipeline, returning the url of the new execution
 
 **Kind**: instance method of [<code>CloudManagerAPI</code>](#CloudManagerAPI)  
 **Returns**: <code>Promise.&lt;string&gt;</code> - the execution url  

--- a/test/jest/data/newExecution.json
+++ b/test/jest/data/newExecution.json
@@ -1,0 +1,16 @@
+{
+    "_links" : {
+        "self" : {
+            "href" : "/api/program/5/pipeline/5/execution/5000"
+        }
+    },
+    "id": "5000",
+    "programId": "5",
+    "pipelineId": "5",
+    "artifactsVersion": "2019.523.134947.0000006554",
+    "trigger": "MANUAL",
+    "user": "3E8367615C0A78710A495EEF@AdobeID",
+    "status": "RUNNING",
+    "createdAt": "2019-05-23T13:49:47.688+0000",
+    "updatedAt": "2019-05-23T13:56:43.811+0000"
+}

--- a/test/jest/jest.fetch.setup.js
+++ b/test/jest/jest.fetch.setup.js
@@ -533,7 +533,8 @@ mockResponseWithMethod('https://cloudmanager.adobe.io/api/program/5/pipeline/5/e
   status: 201,
   headers: {
     location: 'https://cloudmanager.adobe.io/api/program/4/pipeline/8555/execution/12742'
-  }
+  },
+  body: require('./data/newExecution.json')
 })
 fetchMock.mock('https://cloudmanager.adobe.io/api/program/5/environments', {
   _embedded: {

--- a/test/start-execution.test.js
+++ b/test/start-execution.test.js
@@ -55,5 +55,5 @@ test('startExecution - success', async () => {
   const result = sdkClient.startExecution('5', '5')
 
   await expect(result instanceof Promise).toBeTruthy()
-  await expect(result).resolves.toEqual('https://cloudmanager.adobe.io/api/program/4/pipeline/8555/execution/12742')
+  await expect(result).resolves.toEqual('https://cloudmanager.adobe.io/api/program/5/pipeline/5/execution/5000')
 })

--- a/types.d.ts
+++ b/types.d.ts
@@ -66,7 +66,14 @@ declare class CloudManagerAPI {
      */
     listPipelines(programId: string, options: ListPipelineOptions): Promise<Pipeline[]>;
     /**
-     * Start an execution for a pipeline
+     * Create a new execution for a pipeline, returning the execution.
+     * @param programId - the program id
+     * @param pipelineId - the pipeline id
+     * @returns the new execution
+     */
+    createExecution(programId: string, pipelineId: string): Promise<PipelineExecution>;
+    /**
+     * Start an execution for a pipeline, returning the url of the new execution
      * @param programId - the program id
      * @param pipelineId - the pipeline id
      * @returns the execution url


### PR DESCRIPTION
…. fixes #10

<!--- Provide a general summary of your changes in the Title above -->

## Description

* Deprecate startExecution
* Define new createExecution method

## Related Issue

#10

## Motivation and Context

Returning the full execution is more useful

## How Has This Been Tested?

* unit testing
* manual testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
