### PR TITLE
feat(commerce): add getCommerceCLICommand. fixes #178

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ with valid values for tenantId, apiKey and accessToken
     * [.deleteIpAllowlist(programId, ipAllowlistId)](#CloudManagerAPI+deleteIpAllowlist) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.addIpAllowlistBinding(programId, ipAllowlistId, environmentId, service)](#CloudManagerAPI+addIpAllowlistBinding) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.removeIpAllowlistBinding(programId, ipAllowlistId, environmentId, service)](#CloudManagerAPI+removeIpAllowlistBinding) ⇒ <code>Promise.&lt;object&gt;</code>
+    * [.getCommerceCommandExecution(programId, environmentId, executionId)](#CloudManagerAPI+getCommerceCommandExecution) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.postCommerceCommandExecution(programId, environmentId, options)](#CloudManagerAPI+postCommerceCommandExecution) ⇒ <code>Promise.&lt;object&gt;</code>
 
 <a name="CloudManagerAPI+orgId"></a>
@@ -621,6 +622,20 @@ Unbind an IP Allow List from an environment
 | ipAllowlistId | <code>string</code> | the allow list id |
 | environmentId | <code>string</code> | the environment id |
 | service | <code>string</code> | the service name |
+
+<a name="CloudManagerAPI+getCommerceCommandExecution"></a>
+
+### cloudManagerAPI.getCommerceCommandExecution(programId, environmentId, executionId) ⇒ <code>Promise.&lt;object&gt;</code>
+Get the specific commerce execution command status based on the execution id
+
+**Kind**: instance method of [<code>CloudManagerAPI</code>](#CloudManagerAPI)  
+**Returns**: <code>Promise.&lt;object&gt;</code> - a truthy value  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| programId | <code>string</code> | the program id |
+| environmentId | <code>string</code> | the environment id |
+| executionId | <code>string</code> | the execution id |
 
 <a name="CloudManagerAPI+postCommerceCommandExecution"></a>
 

--- a/src/SDKErrors.js
+++ b/src/SDKErrors.js
@@ -104,5 +104,6 @@ E('ERROR_DELETE_IP_ALLOWLIST_BINDING', 'Could not remove IP Allow List binding: 
 E('ERROR_UNSUPPORTED_ADVANCE_STEP', 'Advancing the step %s is not supported in the CLI at present.')
 E('ERROR_REFRESH_STEP_STATE', 'Cannot refresh step state: %s')
 E('ERROR_STEP_STATE_NOT_RUNNING', 'The %s step in execution %s is not currently running.')
+E('ERROR_GET_COMMERCE_CLI', 'Could not get Commerce Command Execution: %s')
 E('ERROR_POST_COMMERCE_CLI', 'Could not post to Commerce CLI endpoint: %s')
 E('ERROR_COMMERCE_CLI', 'Environment %s does not appear to support Commerce CLI')

--- a/src/constants.js
+++ b/src/constants.js
@@ -30,6 +30,7 @@ module.exports = {
     ipAllowlists: 'http://ns.adobe.com/adobecloud/rel/ipAllowlists',
     ipAllowlistBindings: 'http://ns.adobe.com/adobecloud/rel/ipAllowlistBindings',
     commerceCommandExecution: 'http://ns.adobe.com/adobecloud/rel/commerceCommandExecution',
+    commerceCommandExecutionId: 'http://ns.adobe.com/adobecloud/rel/commerceCommandExecution/id',
   },
   config: {
     programId: 'cloudmanager_programid',

--- a/src/index.js
+++ b/src/index.js
@@ -1227,6 +1227,32 @@ class CloudManagerAPI {
   }
 
   /**
+   * Get status for an existing Commerce execution
+   *
+   * @param {string} programId - the program id
+   * @param {string} environmentId - the environment id
+   * @param {string} executionId - the execution id
+   * @returns {Promise<object>} a truthy value of the commerce execution
+   */
+  async getCommerceCommandExecution (programId, environmentId, executionId) {
+    const environment = await this._findEnvironment(programId, environmentId)
+    const environmentLink = environment.link(rels.commerceCommandExecutionId)
+
+    if (!environmentLink) {
+      throw new codes.ERROR_COMMERCE_CLI({ messageValues: environmentId })
+    }
+
+    const executionTemplate = UriTemplate.parse(environmentLink.href)
+    const executionLink = executionTemplate.expand({ executionId: executionId })
+
+    return this._get(executionLink, codes.ERROR_GET_COMMERCE_CLI).then(async res => {
+      return halfred.parse(await res.json())
+    }, e => {
+      throw e
+    })
+  }
+
+  /**
    * Make a Post to Commerce API
    *
    * @param {string} programId - the program id

--- a/test/commerce.test.js
+++ b/test/commerce.test.js
@@ -52,3 +52,73 @@ test('postCommerceCommandExecution - error: no link', async () => {
     new codes.ERROR_COMMERCE_CLI({ messageValues: '11' }),
   )
 })
+
+test('getCommerceCommandExecution - error: failure to find correct environment', async () => {
+  expect.assertions(2)
+
+  const sdkClient = await createSdkClient()
+  const result = sdkClient.getCommerceCommandExecution('4', '3')
+
+  await expect(result instanceof Promise).toBeTruthy()
+  await expect(result).rejects.toEqual(
+    new codes.ERROR_GET_COMMERCE_CLI({ messageValues: 'https://cloudmanager.adobe.io/api/program/4/environment/3/runtime/commerce/command-execution/ (403 Forbidden)' }),
+  )
+})
+
+test('getCommerceCommandExecution - error: failure to retrieve environments', async () => {
+  expect.assertions(2)
+
+  const sdkClient = await createSdkClient()
+  const result = sdkClient.getCommerceCommandExecution('6', '7', '8')
+
+  await expect(result instanceof Promise).toBeTruthy()
+  await expect(result).rejects.toEqual(
+    new codes.ERROR_RETRIEVE_ENVIRONMENTS({ messageValues: 'https://cloudmanager.adobe.io/api/program/6/environments (404 Not Found)' }),
+  )
+})
+
+test('getCommerceCommandExecution - error: no link', async () => {
+  expect.assertions(2)
+
+  const sdkClient = await createSdkClient()
+  const result = sdkClient.getCommerceCommandExecution('4', '11')
+
+  await expect(result instanceof Promise).toBeTruthy()
+  await expect(result).rejects.toEqual(
+    new codes.ERROR_COMMERCE_CLI({ messageValues: '11' }),
+  )
+})
+
+test('getCommerceCommandExecution - success', async () => {
+  expect.assertions(2)
+
+  const sdkClient = await createSdkClient()
+  const result = sdkClient.getCommerceCommandExecution('4', '10', '1')
+
+  await expect(result instanceof Promise).toBeTruthy()
+  await expect(result).resolves.toMatchObject(halfred.parse({
+    id: 1,
+    status: 'RUNNNG', // PENDING, RUNNING, COMPLETED, FAILED
+    type: 'bin/magento', // bin/magento, bin/ece-tools
+    command: 'test command to be executed',
+    message: 'One line message on the progress of command',
+    options: ['Optional', 'inputs provided part of the command'],
+    startedAt: 'timestamp UTC',
+    completedAt: 'timestamp utc',
+    startedBy: 'test runner',
+    _links: {
+      self: {
+        href: '/api/program/4/environment/10/runtime/commerce/command-execution/1',
+      },
+      'http://ns.adobe.com/adobecloud/rel/program': {
+        href: '/api/program/4',
+      },
+      'http://ns.adobe.com/adobecloud/rel/environments': {
+        href: '/api/program/4/environments',
+      },
+      'http://ns.adobe.com/adobecloud/rel/commerceCommandExecutions': {
+        href: '/api/program/4/environment/10/runtime/commerce/command-executions',
+      },
+    },
+  }))
+})

--- a/test/jest/jest.fetch.setup.js
+++ b/test/jest/jest.fetch.setup.js
@@ -249,6 +249,10 @@ beforeEach(() => {
                 'http://ns.adobe.com/adobecloud/rel/commerceCommandExecution': {
                   href: '/api/program/4/environment/3/runtime/commerce/cli/',
                 },
+                'http://ns.adobe.com/adobecloud/rel/commerceCommandExecution/id': {
+                  href: '/api/program/4/environment/3/runtime/commerce/command-execution/{executionId}',
+                  templated: true,
+                },
               },
               id: '3',
               programId: '4',
@@ -267,6 +271,10 @@ beforeEach(() => {
                 },
                 'http://ns.adobe.com/adobecloud/rel/commerceCommandExecution': {
                   href: '/api/program/4/environment/10/runtime/commerce/cli/',
+                },
+                'http://ns.adobe.com/adobecloud/rel/commerceCommandExecution/id': {
+                  href: '/api/program/4/environment/10/runtime/commerce/command-execution/{executionId}',
+                  templated: true,
                 },
               },
               id: '10',
@@ -1644,6 +1652,36 @@ beforeEach(() => {
     },
   })
   fetchMock.mock('https://cloudmanager.adobe.io/api/program/9/ipAllowlists', 400)
+
+  // Commerce command execution mocks
+  fetchMock.mock('https://cloudmanager.adobe.io/api/program/4/environment/3/runtime/commerce/command-execution/', 403)
+  fetchMock.mock('https://cloudmanager.adobe.io/api/program/6/environment/7/runtime/commerce/command-execution/8', 404)
+
+  mockResponseWithMethod('https://cloudmanager.adobe.io/api/program/4/environment/10/runtime/commerce/command-execution/1', 'GET', {
+    id: 1,
+    status: 'RUNNNG', // PENDING, RUNNING, COMPLETED, FAILED
+    type: 'bin/magento', // bin/magento, bin/ece-tools
+    command: 'test command to be executed',
+    message: 'One line message on the progress of command',
+    options: ['Optional', 'inputs provided part of the command'],
+    startedAt: 'timestamp UTC',
+    completedAt: 'timestamp utc',
+    startedBy: 'test runner',
+    _links: {
+      self: {
+        href: '/api/program/4/environment/10/runtime/commerce/command-execution/1',
+      },
+      'http://ns.adobe.com/adobecloud/rel/program': {
+        href: '/api/program/4',
+      },
+      'http://ns.adobe.com/adobecloud/rel/environments': {
+        href: '/api/program/4/environments',
+      },
+      'http://ns.adobe.com/adobecloud/rel/commerceCommandExecutions': {
+        href: '/api/program/4/environment/10/runtime/commerce/command-executions',
+      },
+    },
+  })
 
   mockResponseWithMethod('https://cloudmanager.adobe.io/api/program/4/environment/10/runtime/commerce/cli/', 'POST', {
     status: 201,


### PR DESCRIPTION
Added getCommerceCLICommand

## Description

- Added  call for Commerce cloudmanager CLI
- updated unit tests to include coverage for new GET commerce CLI call
- Updated documentation to include newly added GET commerce CLI call

## Related Issue

#178 

## Motivation and Context

Expands Adobe Commerce functionality to the CLI

## How Has This Been Tested?

Unit tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
