### PR TITLE
chore(test): enable the use of jest-extended matchers

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "fetch-mock": "9.11.0",
     "husky": "5.2.0",
     "jest": "27.0.6",
+    "jest-extended": "0.11.5",
     "jest-junit": "12.2.0",
     "js-yaml": "4.1.0",
     "jscpd": "3.3.26",

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -29,6 +29,7 @@ module.exports = {
   testEnvironment: 'node',
   setupFilesAfterEnv: [
     '<rootDir>/test/jest/jest.setup.js',
+    'jest-extended',
     '<rootDir>/test/jest/jest.zlib.setup.js',
     // remove any of the lines below if you don't want to use any of the mocks
     '<rootDir>/test/jest/jest.fetch.setup.js',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add jest-extended and enable its use in test modules

## Related Issue

n/a -- test support only

## Motivation and Context

Would be helpful in the future and warrants dividing from any given test change.

## How Has This Been Tested?

n/a

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
