### PR TITLE
feat(commerce): add getCommerceCommandExecutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "cross-fetch": "^3.0.4",
     "halfred": "^2.0.0",
     "lodash": "^4.17.20",
+    "urijs": "^1.19.7",
     "uritemplate": "^0.3.4"
   },
   "devDependencies": {

--- a/src/constants.js
+++ b/src/constants.js
@@ -30,6 +30,7 @@ module.exports = {
     ipAllowlists: 'http://ns.adobe.com/adobecloud/rel/ipAllowlists',
     ipAllowlistBindings: 'http://ns.adobe.com/adobecloud/rel/ipAllowlistBindings',
     commerceCommandExecution: 'http://ns.adobe.com/adobecloud/rel/commerceCommandExecution',
+    commerceCommandExecutions: 'http://ns.adobe.com/adobecloud/rel/commerceCommandExecutions',
     commerceCommandExecutionId: 'http://ns.adobe.com/adobecloud/rel/commerceCommandExecution/id',
     pipelineCache: 'http://ns.adobe.com/adobecloud/rel/cache',
     commerceLogs: 'http://ns.adobe.com/adobecloud/rel/commerceCommandExecution/logs',

--- a/test/commerce.test.js
+++ b/test/commerce.test.js
@@ -122,3 +122,87 @@ test('getCommerceCommandExecution - success', async () => {
     },
   }))
 })
+
+test('getCommerceCommandExecutions - error: failure to find correct environment', async () => {
+  expect.assertions(2)
+
+  const sdkClient = await createSdkClient()
+  const result = sdkClient.getCommerceCommandExecutions('4', '3')
+
+  await expect(result instanceof Promise).toBeTruthy()
+  await expect(result).rejects.toEqual(
+    new codes.ERROR_GET_COMMERCE_CLI({ messageValues: 'https://cloudmanager.adobe.io/api/program/4/environment/10/runtime/commerce/command-executions (403 Forbidden)' }),
+  )
+})
+
+test('getCommerceCommandExecutions - error: failure to retrieve environments', async () => {
+  expect.assertions(2)
+
+  const sdkClient = await createSdkClient()
+  const result = sdkClient.getCommerceCommandExecutions('6', '7')
+
+  await expect(result instanceof Promise).toBeTruthy()
+  await expect(result).rejects.toEqual(
+    new codes.ERROR_RETRIEVE_ENVIRONMENTS({ messageValues: 'https://cloudmanager.adobe.io/api/program/6/environments (404 Not Found)' }),
+  )
+})
+
+test('getCommerceCommandExecutions - error: no link', async () => {
+  expect.assertions(2)
+
+  const sdkClient = await createSdkClient()
+  const result = sdkClient.getCommerceCommandExecutions('4', '11')
+
+  await expect(result instanceof Promise).toBeTruthy()
+  await expect(result).rejects.toEqual(
+    new codes.ERROR_COMMERCE_CLI({ messageValues: '11' }),
+  )
+})
+
+test('getCommerceCommandExecutions - success', async () => {
+  expect.assertions(2)
+
+  const sdkClient = await createSdkClient()
+  const result = sdkClient.getCommerceCommandExecutions('4', '10', 'bin/magento', 'COMPLETE', 'cache:clean')
+
+  await expect(result instanceof Promise).toBeTruthy()
+  await expect(result).resolves.toMatchObject(halfred.parse({
+    _embedded: {
+      commandExecutions: [
+        {
+          _links: {
+            'http://ns.adobe.com/adobecloud/rel/commerceCommandExecution': {
+              href: '/api/program/4/environment/10/runtime/commerce/command-execution/2553',
+              templated: false,
+            },
+            'http://ns.adobe.com/adobecloud/rel/commerceCommandExecution/logs': {
+              href: '/api/program/4/environment/10/runtime/commerce/command-execution/2553/logs',
+              templated: false,
+            },
+            'http://ns.adobe.com/adobecloud/rel/environment': {
+              href: '/api/program/4/environment/10',
+              templated: false,
+            },
+          },
+          id: 2553,
+          type: 'bin/magento',
+          command: 'cache:clean',
+          options: [],
+          startedBy: 'E64A64C360706AD20A494012@techacct.adobe.com',
+          startedAt: '2021-08-31T15:31:16.901+0000',
+          completedAt: '2021-08-31T15:32:18.000+0000',
+          name: 'magento-cli-2553',
+          status: 'COMPLETED',
+          environmentId: 180972,
+        },
+      ],
+    },
+    _totalNumberOfItems: 1,
+    _page: {
+      limit: 20,
+      property: [],
+      next: 20,
+      prev: 0,
+    },
+  }).embeddedArray('commandExecutions'))
+})

--- a/test/jest/jest.fetch.setup.js
+++ b/test/jest/jest.fetch.setup.js
@@ -249,6 +249,10 @@ beforeEach(() => {
                 'http://ns.adobe.com/adobecloud/rel/commerceCommandExecution': {
                   href: '/api/program/4/environment/3/runtime/commerce/cli/',
                 },
+                'http://ns.adobe.com/adobecloud/rel/commerceCommandExecutions': {
+                  href: '/api/program/4/environment/10/runtime/commerce/command-executions',
+                  templated: true,
+                },
                 'http://ns.adobe.com/adobecloud/rel/commerceCommandExecution/id': {
                   href: '/api/program/4/environment/3/runtime/commerce/command-execution/{commandExecutionId}',
                   templated: true,
@@ -271,6 +275,10 @@ beforeEach(() => {
                 },
                 'http://ns.adobe.com/adobecloud/rel/commerceCommandExecution': {
                   href: '/api/program/4/environment/10/runtime/commerce/cli/',
+                },
+                'http://ns.adobe.com/adobecloud/rel/commerceCommandExecutions': {
+                  href: '/api/program/4/environment/10/runtime/commerce/command-executions',
+                  templated: true,
                 },
                 'http://ns.adobe.com/adobecloud/rel/commerceCommandExecution/logs': {
                   href: '/api/program/4/pipeline/10/runtime/commerce/command-execution/{commandExecutionId}/logs',
@@ -1687,6 +1695,7 @@ beforeEach(() => {
   // Commerce command execution mocks
   fetchMock.mock('https://cloudmanager.adobe.io/api/program/4/environment/3/runtime/commerce/command-execution/', 403)
   fetchMock.mock('https://cloudmanager.adobe.io/api/program/6/environment/7/runtime/commerce/command-execution/8', 404)
+  fetchMock.mock('https://cloudmanager.adobe.io/api/program/4/environment/10/runtime/commerce/command-executions', 403)
 
   mockResponseWithMethod('https://cloudmanager.adobe.io/api/program/4/environment/10/runtime/commerce/command-execution/1', 'GET', {
     id: 1,
@@ -1800,6 +1809,47 @@ beforeEach(() => {
       },
     }
   })
+
+  mockResponseWithMethod('https://cloudmanager.adobe.io/api/program/4/environment/10/runtime/commerce/command-executions?property=type%3D%3Dbin%2Fmagento&property=status%3D%3DCOMPLETE&property=command%3D%3Dcache%3Aclean', 'GET', () =>
+    ({
+      _embedded: {
+        commandExecutions: [
+          {
+            _links: {
+              'http://ns.adobe.com/adobecloud/rel/commerceCommandExecution': {
+                href: '/api/program/4/environment/10/runtime/commerce/command-execution/2553',
+                templated: false,
+              },
+              'http://ns.adobe.com/adobecloud/rel/commerceCommandExecution/logs': {
+                href: '/api/program/4/environment/10/runtime/commerce/command-execution/2553/logs',
+                templated: false,
+              },
+              'http://ns.adobe.com/adobecloud/rel/environment': {
+                href: '/api/program/4/environment/10',
+                templated: false,
+              },
+            },
+            id: 2553,
+            type: 'bin/magento',
+            command: 'cache:clean',
+            options: [],
+            startedBy: 'E64A64C360706AD20A494012@techacct.adobe.com',
+            startedAt: '2021-08-31T15:31:16.901+0000',
+            completedAt: '2021-08-31T15:32:18.000+0000',
+            name: 'magento-cli-2553',
+            status: 'COMPLETED',
+            environmentId: 180972,
+          },
+        ],
+      },
+      _totalNumberOfItems: 1,
+      _page: {
+        limit: 20,
+        property: [],
+        next: 20,
+        prev: 0,
+      },
+    }))
 
   mockResponseWithMethod('https://cloudmanager.adobe.io/api/program/4/environment/10/runtime/commerce/cli/', 'POST', {
     status: 201,


### PR DESCRIPTION
fixes #220

## Description

Commerce will need a method in the lib that will expose the API endpoint that lists all of the commands associated with an environment

## Related Issue

https://github.com/adobe/aio-lib-cloudmanager/issues/220


## How Has This Been Tested?

- unit tests
- local development environment

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
