### PR TITLE
feat(commerce): add getCommerceCommandExecutions. fixes #219

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ with valid values for tenantId, apiKey and accessToken
     * [.deleteIpAllowlist(programId, ipAllowlistId)](#CloudManagerAPI+deleteIpAllowlist) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.addIpAllowlistBinding(programId, ipAllowlistId, environmentId, service)](#CloudManagerAPI+addIpAllowlistBinding) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.removeIpAllowlistBinding(programId, ipAllowlistId, environmentId, service)](#CloudManagerAPI+removeIpAllowlistBinding) ⇒ <code>Promise.&lt;object&gt;</code>
+    * [.getCommerceCommandExecutions(programId, environmentId, type, status, command)](#CloudManagerAPI+getCommerceCommandExecutions) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.postCommerceCommandExecution(programId, environmentId, options)](#CloudManagerAPI+postCommerceCommandExecution) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.getCommerceCommandExecution(programId, environmentId, commandExecutionId)](#CloudManagerAPI+getCommerceCommandExecution) ⇒ <code>Promise.&lt;object&gt;</code>
 
@@ -636,6 +637,23 @@ Unbind an IP Allow List from an environment
 | ipAllowlistId | <code>string</code> | the allow list id |
 | environmentId | <code>string</code> | the environment id |
 | service | <code>string</code> | the service name |
+
+<a name="CloudManagerAPI+getCommerceCommandExecutions"></a>
+
+### cloudManagerAPI.getCommerceCommandExecutions(programId, environmentId, type, status, command) ⇒ <code>Promise.&lt;object&gt;</code>
+Get list of Commerce Command Executions based off search params
+
+**Kind**: instance method of [<code>CloudManagerAPI</code>](#CloudManagerAPI)  
+**Returns**: <code>Promise.&lt;object&gt;</code> - a truthy value of the commerce execution  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| programId | <code>string</code> | the program id |
+| environmentId | <code>string</code> | the environment id |
+| type | <code>string</code> | the type of command execution to filter on |
+| status | <code>string</code> | the status of the command to filter on |
+| command | <code>string</code> | the command(s) to filter on |
+
 
 <a name="CloudManagerAPI+postCommerceCommandExecution"></a>
 

--- a/src/SDKErrors.js
+++ b/src/SDKErrors.js
@@ -104,6 +104,7 @@ E('ERROR_DELETE_IP_ALLOWLIST_BINDING', 'Could not remove IP Allow List binding: 
 E('ERROR_UNSUPPORTED_ADVANCE_STEP', 'Advancing the step %s is not supported in the CLI at present.')
 E('ERROR_REFRESH_STEP_STATE', 'Cannot refresh step state: %s')
 E('ERROR_STEP_STATE_NOT_RUNNING', 'The %s step in execution %s is not currently running.')
+E('ERROR_GET_COMMERCE_COMMAND_EXECUTIONS_CLI', 'Could not get Commerce Command Executions')
 E('ERROR_GET_COMMERCE_CLI', 'Could not get Commerce Command Execution: %s')
 E('ERROR_POST_COMMERCE_CLI', 'Could not post to Commerce CLI endpoint: %s')
 E('ERROR_COMMERCE_CLI', 'Environment %s does not appear to support Commerce CLI')

--- a/src/constants.js
+++ b/src/constants.js
@@ -29,6 +29,7 @@ module.exports = {
     variables: 'http://ns.adobe.com/adobecloud/rel/variables',
     ipAllowlists: 'http://ns.adobe.com/adobecloud/rel/ipAllowlists',
     ipAllowlistBindings: 'http://ns.adobe.com/adobecloud/rel/ipAllowlistBindings',
+    commerceCommandExecutions: 'http://ns.adobe.com/adobecloud/rel/commerceCommandExecutions',
     commerceCommandExecution: 'http://ns.adobe.com/adobecloud/rel/commerceCommandExecution',
     commerceCommandExecutionId: 'http://ns.adobe.com/adobecloud/rel/commerceCommandExecution/id',
     pipelineCache: 'http://ns.adobe.com/adobecloud/rel/cache',

--- a/src/index.js
+++ b/src/index.js
@@ -1254,6 +1254,47 @@ class CloudManagerAPI {
   }
 
   /**
+   * Get list of Commerce Command Executions based off search params
+   *
+   * @param {string} programId - the program id
+   * @param {string} environmentId - the environment id
+   * @param {string} type - the type of command execution to filter on
+   * @param {string} status - the status of the command to filter on
+   * @param {string} command - the command(s) to filter on
+   * @returns {Promise<object>} a truthy value of the commerce command executions
+   */
+  async getCommerceCommandExecutions (programId, environmentId, type = '', status = '', command = '') {
+    const environment = await this._findEnvironment(programId, environmentId)
+    const environmentLink = environment.link(rels.commerceCommandExecutions)
+
+    if (!environmentLink) {
+      throw new codes.ERROR_COMMERCE_CLI({ messageValues: environmentId })
+    }
+
+    let queryParams = ''
+
+    if (type) {
+      queryParams += `property=type==${type}&`
+    }
+
+    if (status) {
+      queryParams += `property=status==${status}&`
+    }
+
+    if (command) {
+      queryParams += `property=command==${command}`
+    }
+
+    const executionLink = environmentLink.href + (queryParams ? `?${queryParams}` : '')
+
+    return this._get(executionLink, codes.ERROR_GET_COMMERCE_COMMAND_EXECUTIONS_CLI).then(async res => {
+      return halfred.parse(await res.json())
+    }, e => {
+      throw e
+    })
+  }
+
+  /**
    * Make a Post to Commerce API
    *
    * @param {string} programId - the program id

--- a/test/commerce.test.js
+++ b/test/commerce.test.js
@@ -14,6 +14,105 @@ const halfred = require('halfred')
 
 /* global createSdkClient */ // for linter
 
+test('getCommerceCommandExecutions - success', async () => {
+  expect.assertions(2)
+
+  const sdkClient = await createSdkClient()
+  const result = sdkClient.getCommerceCommandExecutions('4', '10', 'bin/magento', 'COMPLETED', 'cache:clean')
+
+  await expect(result instanceof Promise).toBeTruthy()
+  await expect(result).resolves.toMatchObject(halfred.parse({
+    _embedded: {
+      commandExecutions: [{
+        _links: {
+          'http://ns.adobe.com/adobecloud/rel/commerceCommandExecution': {
+            href: '/api/program/4/environment/10/runtime/commerce/command-execution/50',
+            templated: false,
+          },
+          'http://ns.adobe.com/adobecloud/rel/commerceCommandExecution/logs': {
+            href: '/api/program/4/environment/10/runtime/commerce/command-execution/50/logs',
+            templated: false,
+          },
+          'http://ns.adobe.com/adobecloud/rel/environment': {
+            href: '/api/program/4/environment/10',
+            templated: false,
+          },
+        },
+        id: 50,
+        type: 'bin/magento',
+        command: 'cache:clean',
+        options: [],
+        startedBy: 'E64A64C360706AD20A494012@techacct.adobe.com',
+        startedAt: '2021-08-31T15:31:16.901+0000',
+        completedAt: '2021-08-31T15:32:18.000+0000',
+        name: 'magento-cli-2553',
+        status: 'COMPLETED',
+        environmentId: 12,
+      }, {
+        _links: {
+          'http://ns.adobe.com/adobecloud/rel/commerceCommandExecution': {
+            href: '/api/program/4/environment/10/runtime/commerce/command-execution/51',
+            templated: false,
+          },
+          'http://ns.adobe.com/adobecloud/rel/commerceCommandExecution/logs': {
+            href: '/api/program/4/environment/10/runtime/commerce/command-execution/51/logs',
+            templated: false,
+          },
+          'http://ns.adobe.com/adobecloud/rel/environment': {
+            href: '/api/program/4/environment/10',
+            templated: false,
+          },
+        },
+        id: 51,
+        type: 'bin/magento',
+        command: 'cache:clean',
+        options: [],
+        startedBy: '75CF04FB5D3EB9E20A49422F@AdobeID',
+        startedAt: '2021-08-30T17:06:39.633+0000',
+        completedAt: '2021-08-30T17:07:29.000+0000',
+        name: 'magento-cli-2461',
+        status: 'COMPLETED',
+        environmentId: 12,
+      }],
+    },
+    _totalNumberOfItems: 2,
+    _page: {
+      limit: 20,
+      property: [
+        'type==bin/magento',
+        'status==COMPLETED',
+        'command==cache:clean',
+      ],
+      next: 20,
+      prev: 0,
+    },
+  }))
+})
+
+test('getCommerceCommandExecutions - error: no hal link for executions', async () => {
+  expect.assertions(2)
+
+  const sdkClient = await createSdkClient()
+  const result = sdkClient.getCommerceCommandExecutions('4', '11', 'bin/magento', 'COMPLETED', 'cache:clean')
+
+  await expect(result instanceof Promise).toBeTruthy()
+  await expect(result).rejects.toEqual(
+    new codes.ERROR_COMMERCE_CLI({ messageValues: '11' }),
+  )
+})
+
+test('getCommerceCommandExecutions - error: failure to find correct environment for all commerce command exectuions', async () => {
+  expect.assertions(2)
+
+  const sdkClient = await createSdkClient()
+  const result = sdkClient.getCommerceCommandExecutions('4', '3', 'bin/magento', 'COMPLETED', 'cache:clean')
+
+  await expect(result instanceof Promise).toBeTruthy()
+  await expect(result).rejects.toEqual(
+    new codes.ERROR_GET_COMMERCE_COMMAND_EXECUTIONS_CLI({ messageValues: 'https://cloudmanager.adobe.io/api/program/4/environment/3/runtime/commerce/command-executions/?property=type==bin/magento&property=status==COMPLETED&property=command==cache:clean (403 Forbidden)' }),
+  )
+})
+
 test('postCommerceCommandExecution - success', async () => {
   expect.assertions(2)
 

--- a/test/jest/jest.fetch.setup.js
+++ b/test/jest/jest.fetch.setup.js
@@ -253,6 +253,10 @@ beforeEach(() => {
                   href: '/api/program/4/environment/3/runtime/commerce/command-execution/{commandExecutionId}',
                   templated: true,
                 },
+                'http://ns.adobe.com/adobecloud/rel/commerceCommandExecutions': {
+                  href: '/api/program/4/environment/3/runtime/commerce/command-executions/',
+                  templated: true,
+                },
               },
               id: '3',
               programId: '4',
@@ -277,6 +281,10 @@ beforeEach(() => {
                 },
                 'http://ns.adobe.com/adobecloud/rel/commerceCommandExecution/id': {
                   href: '/api/program/4/environment/10/runtime/commerce/command-execution/{commandExecutionId}',
+                  templated: true,
+                },
+                'http://ns.adobe.com/adobecloud/rel/commerceCommandExecutions': {
+                  href: '/api/program/4/environment/10/runtime/commerce/command-executions/',
                   templated: true,
                 },
               },
@@ -1685,6 +1693,74 @@ beforeEach(() => {
   fetchMock.mock('https://cloudmanager.adobe.io/api/program/9/ipAllowlists', 400)
 
   // Commerce command execution mocks
+  mockResponseWithMethod('https://cloudmanager.adobe.io/api/program/4/environment/10/runtime/commerce/command-executions/?property=type==bin/magento&property=status==COMPLETED&property=command==cache:clean', 'GET', {
+    _embedded: {
+      commandExecutions: [{
+        _links: {
+          'http://ns.adobe.com/adobecloud/rel/commerceCommandExecution': {
+            href: '/api/program/4/environment/10/runtime/commerce/command-execution/50',
+            templated: false,
+          },
+          'http://ns.adobe.com/adobecloud/rel/commerceCommandExecution/logs': {
+            href: '/api/program/4/environment/10/runtime/commerce/command-execution/50/logs',
+            templated: false,
+          },
+          'http://ns.adobe.com/adobecloud/rel/environment': {
+            href: '/api/program/4/environment/10',
+            templated: false,
+          },
+        },
+        id: 50,
+        type: 'bin/magento',
+        command: 'cache:clean',
+        options: [],
+        startedBy: 'E64A64C360706AD20A494012@techacct.adobe.com',
+        startedAt: '2021-08-31T15:31:16.901+0000',
+        completedAt: '2021-08-31T15:32:18.000+0000',
+        name: 'magento-cli-2553',
+        status: 'COMPLETED',
+        environmentId: 12,
+      }, {
+        _links: {
+          'http://ns.adobe.com/adobecloud/rel/commerceCommandExecution': {
+            href: '/api/program/4/environment/10/runtime/commerce/command-execution/51',
+            templated: false,
+          },
+          'http://ns.adobe.com/adobecloud/rel/commerceCommandExecution/logs': {
+            href: '/api/program/4/environment/10/runtime/commerce/command-execution/51/logs',
+            templated: false,
+          },
+          'http://ns.adobe.com/adobecloud/rel/environment': {
+            href: '/api/program/4/environment/10',
+            templated: false,
+          },
+        },
+        id: 51,
+        type: 'bin/magento',
+        command: 'cache:clean',
+        options: [],
+        startedBy: '75CF04FB5D3EB9E20A49422F@AdobeID',
+        startedAt: '2021-08-30T17:06:39.633+0000',
+        completedAt: '2021-08-30T17:07:29.000+0000',
+        name: 'magento-cli-2461',
+        status: 'COMPLETED',
+        environmentId: 12,
+      }],
+    },
+    _totalNumberOfItems: 2,
+    _page: {
+      limit: 20,
+      property: [
+        'type==bin/magento',
+        'status==COMPLETED',
+        'command==cache:clean',
+      ],
+      next: 20,
+      prev: 0,
+    },
+  })
+
+  fetchMock.mock('https://cloudmanager.adobe.io/api/program/4/environment/3/runtime/commerce/command-executions/?property=type==bin/magento&property=status==COMPLETED&property=command==cache:clean', 403)
   fetchMock.mock('https://cloudmanager.adobe.io/api/program/4/environment/3/runtime/commerce/command-execution/', 403)
   fetchMock.mock('https://cloudmanager.adobe.io/api/program/6/environment/7/runtime/commerce/command-execution/8', 404)
 


### PR DESCRIPTION
Added getCommerceCLICommand

## Description

- Added `getCommerceCommandExecutions` call for Commerce CLI
- Updated unit tests to include coverage for new GET commerce CLI call
- Updated documentation to include newly updated GET commerce CLI call

## Related Issue

#219 

## Motivation and Context

Expands Adobe Commerce functionality to the CLI

## How Has This Been Tested?

Unit tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
