### PR TITLE
feat(commerce-tail-log): fixes commerce #239

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1328,11 +1328,16 @@ class CloudManagerAPI {
 
   async _getTailLogRedirectUrl (href) {
     return this._get(href, codes.ERROR_GET_LOG).then(async (res) => {
-      const json = await res.json()
-      if (json.redirect) {
-        return json.redirect
-      } else {
-        throw new codes.ERROR_NO_LOG_REDIRECT({ messageValues: [res.url, JSON.stringify(json)] })
+      if (res.status === 200) {
+        const json = await res.json()
+        if (json.redirect) {
+          return json.redirect
+        } else {
+          throw new codes.ERROR_NO_LOG_REDIRECT({ messageValues: [res.url, JSON.stringify(json)] })
+        }
+      } else if (res.status === 204) {
+        await sleep(3000)
+        return this._getTailLogRedirectUrl(href)
       }
     }, e => {
       throw e

--- a/test/jest/jest.fetch.setup.js
+++ b/test/jest/jest.fetch.setup.js
@@ -1859,12 +1859,20 @@ beforeEach(() => {
   })
   fetchMock.mock('https://cloudmanager.adobe.io/api/program/4/environment/3/runtime/commerce/cli/', 403)
 
-  mockResponseWithMethod('https://cloudmanager.adobe.io/api/program/4/pipeline/10/runtime/commerce/command-execution/708/logs', 'GET', {
-    redirect: 'https://filestore/commerce-tail-logs.txt',
-  })
-
   mockResponseWithMethod('https://cloudmanager.adobe.io/api/program/4/pipeline/10/runtime/commerce/command-execution/7110000/logs', 'GET', {
     redirect: 'https://filestore/commerce-tail-logs-error.txt',
+  })
+
+  let logNotReadyCounter = 0
+  mockResponseWithMethod('https://cloudmanager.adobe.io/api/program/4/pipeline/10/runtime/commerce/command-execution/708/logs', 'GET', () => {
+    if (logNotReadyCounter < 2) {
+      logNotReadyCounter++
+      return 204
+    } else {
+      return {
+        redirect: 'https://filestore/commerce-tail-logs.txt',
+      }
+    }
   })
 
   mockResponseWithMethod('https://cloudmanager.adobe.io/api/program/4/pipeline/10/runtime/commerce/command-execution/7090000/logs', 'GET', {})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I made _getTailLogRedirectUrl a recursive function. So if it gets a 204 from commerce api(request is valid, but content is not ready yet), it will wait for 3 sec and call itself again, if it get's a 200 or error, it behaves same way as before. 

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
