### PR TITLE
chore(ci): add semantic-release-dry-run to ci build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,6 @@ jobs:
     - run: npm install
     - run: npm run generate-docs
     - run: npm test
+    - run: npm run semantic-release-dry-run
     - name: Codecov
       uses: codecov/codecov-action@v2.1.0

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "jsdoc": "jsdoc2md -t ./docs/readme_template.md src/**/*.js > README.md",
     "generate-docs": "npm run generate-jsdoc-types && npm run typings && npm run jsdoc",
     "semantic-release": "semantic-release",
+    "semantic-release-dry-run": "semantic-release --dry-run",
     "prepack": "npm run generate-jsdoc-types && npm run typings",
     "version": "npm run generate-docs && git add README.md",
     "postinstall": "husky install",


### PR DESCRIPTION
Updates to semantic-release weren't detected as problematic because semantic-release is not run during the PR build. Trying to check that...