### PR TITLE
fix(pipeline): add incomplete as a finished state for pipeline steps. Fixes #384

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -18,7 +18,7 @@ governing permissions and limitations under the License.
  * @returns {PipelineExecutionStepState} the step state or a falsy object if all steps are finished
  */
 function getCurrentStep (execution) {
-  return (execution && execution._embedded && execution._embedded.stepStates && execution._embedded.stepStates.filter(ss => ss.status !== 'FINISHED')[0]) || undefined
+  return (execution && execution._embedded && execution._embedded.stepStates && execution._embedded.stepStates.filter(ss => ss.status !== 'FINISHED' && ss.status !== 'INCOMPLETE')[0]) || undefined
 }
 
 /**


### PR DESCRIPTION
## Description

A new status (**incomplete** - which is a final state) for pipeline steps was added in 2023.6.0 release of CM and this prevents in some cases the current step method to actually detect which is the proper current step (the one that is running, waiting, etc.)

## Related Issue

[#384](https://github.com/adobe/aio-lib-cloudmanager/issues/384)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
